### PR TITLE
Update phpunit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ language: php
 
 matrix:
   include:
-    - php: 7.1
-      env: PREFER_LOWEST="--prefer-lowest --prefer-stable"
-    - php: 7.2
-      env: CARBON='1.*'
     - php: 7.3
+      env: PREFER_LOWEST="--prefer-lowest --prefer-stable"
+    - php: 7.3
+      env: CARBON='1.*'
+    - php: 7.4
       env: CARBON='2.*'
   fast_finish: true
 

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.2",
     "nesbot/carbon": "^1.21||^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0||^8.0"
+    "phpunit/phpunit": "^8.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     }
   ],
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.3",
     "nesbot/carbon": "^1.21||^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.0"
+    "phpunit/phpunit": "^9.3"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Updates testing to use *only* latest phpunit 9 and therefore also drops support for php 7.1 & 7.2 for the next release.