### PR TITLE
Use space separator instead of T in datetime local

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ in the `'Y-m-d H:i'` format (e.g. `'2016-08-07 13:37'`), with no timezone inform
 Be kind to your users and display the timezone next to your input, perhaps in the `<label>`
 or in an element referenced through the input's `aria-describedby` attribute.
 
+#### `Carbonator::parseToDatetime($input, $tz_target = null, $tz_parse = null)`
+
+Returns a string formatted in the
+["W3C" format](https://www.php.net/manual/en/class.datetimeinterface.php#datetime.constants.w3c)
+`'Y-m-d\TH:i:sP'` (e.g. `'2016-08-07T13:37:00+00:00'`), suitable for a
+[HTML5 `<time/>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time)'s `datetime` attribute.
+
 ## Figuring out users' timezones
 
 There's no way to know a user's timezone for sure, without asking them.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The string is guaranteed to be in the `$tz_target` timezone.
 #### `Carbonator::parseToDatetimeLocal($input, $tz_target = null, $tz_parse = null)`
 
 Returns a string formatted for a
-[HTML5 `datetime-local` input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local)
+[HTML5 `datetime-local` `<input/> element`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local)
 in the `'Y-m-d H:i'` format (e.g. `'2016-08-07 13:37'`), with no timezone information.
 Be kind to your users and display the timezone next to your input, perhaps in the `<label>`
 or in an element referenced through the input's `aria-describedby` attribute.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The string is guaranteed to be in the `$tz_target` timezone.
 
 Returns a string formatted for a
 [HTML5 `datetime-local` input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local)
-in the `'Y-m-d\TH:i'` format (e.g. `'2016-08-07T13:37'`), with no timezone information.
+in the `'Y-m-d H:i'` format (e.g. `'2016-08-07 13:37'`), with no timezone information.
 Be kind to your users and display the timezone next to your input, perhaps in the `<label>`
 or in an element referenced through the input's `aria-describedby` attribute.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ echo Carbonator::formatInTz($in_utc, 'D, M j, Y H:i T', 'Africa/Windhoek');
 // Populate a HTML5 datetime-local input for a user in Japan:
 $in_utc = Carbon::parse('2016-08-07 13:37');
 echo Carbonator::parseToDatetimeLocal($in_utc, 'Asia/Tokyo');
-// 2016-08-07T22:37
+// 2016-08-07 22:37
 ```
 
 ## Installation & Configuration

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ echo Carbonator::formatInTz($in_utc, 'D, M j, Y H:i T', 'Africa/Windhoek');
 $in_utc = Carbon::parse('2016-08-07 13:37');
 echo Carbonator::parseToDatetimeLocal($in_utc, 'Asia/Tokyo');
 // 2016-08-07 22:37
+
+
+// Populate a HTML5 datetime attribute
+$in_india = Carbon::parse('2016-08-07 13:37', 'Asia/Kolkata');
+echo Carbonator::parseToDatetime($in_india);
+// 2016-08-07T13:37:00+05:30
 ```
 
 ## Installation & Configuration

--- a/examples/examples.php
+++ b/examples/examples.php
@@ -35,6 +35,6 @@ echo "\n\n";
 // Populate a HTML5 datetime-local input for a user in Japan:
 $in_utc = Carbon::parse('2016-08-07 13:37');
 echo Carbonator::parseToDatetimeLocal($in_utc, 'Asia/Tokyo');
-// 2016-08-07T22:37
+// 2016-08-07 22:37
 
 echo "\n\n";

--- a/examples/examples.php
+++ b/examples/examples.php
@@ -38,3 +38,10 @@ echo Carbonator::parseToDatetimeLocal($in_utc, 'Asia/Tokyo');
 // 2016-08-07 22:37
 
 echo "\n\n";
+
+// Populate a HTML5 datetime attribute
+$in_india = Carbon::parse('2016-08-07 13:37', 'Asia/Kolkata');
+echo Carbonator::parseToDatetime($in_india);
+// 2016-08-07T13:37:00+05:30
+
+echo "\n\n";

--- a/src/Carbonator.php
+++ b/src/Carbonator.php
@@ -7,7 +7,7 @@ use DateTimeZone;
 
 class Carbonator
 {
-    const DATETIMELOCAL = 'Y-m-d\TH:i';
+    const DATETIMELOCAL = 'Y-m-d H:i';
 
     /**
      * @param string|DateTime $input

--- a/src/Carbonator.php
+++ b/src/Carbonator.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace FewAgency\Carbonator;
 
 use Carbon\Carbon;

--- a/tests/CarbonatorTest.php
+++ b/tests/CarbonatorTest.php
@@ -87,7 +87,7 @@ class CarbonatorTest extends TestCase
     public function testParseToDatetimeLocal()
     {
         $this->assertEquals(
-            '2016-08-05T12:37',
+            '2016-08-05 12:37',
             Carbonator::parseToDatetimeLocal('2016-08-05 13:37 +01:00')
         );
     }
@@ -95,7 +95,7 @@ class CarbonatorTest extends TestCase
     public function testParseToDatetimeLocalWithTargetTz()
     {
         $this->assertEquals(
-            '2016-08-05T13:37',
+            '2016-08-05 13:37',
             Carbonator::parseToDatetimeLocal('2016-08-05 13:37 +01:00', '+01:00')
         );
     }
@@ -103,7 +103,7 @@ class CarbonatorTest extends TestCase
     public function testParseToDatetimeLocalWithParseTz()
     {
         $this->assertEquals(
-            '2016-08-05T15:37',
+            '2016-08-05 15:37',
             Carbonator::parseToDatetimeLocal('2016-08-05 13:37', '+01:00', '-01:00')
         );
     }


### PR DESCRIPTION
Replace the `T` in local date time formats with a whitespace. This is allowed in html and is much more user friendly whenever a browser doesn't implement a `datetime` input and shows a text input!

This is a **breaking change** and should be released in a new major version.